### PR TITLE
Update CLI for Windows links to v0.10.0

### DIFF
--- a/doc_source/serverless-sam-cli-install-windows.md
+++ b/doc_source/serverless-sam-cli-install-windows.md
@@ -16,8 +16,8 @@ Verify that Docker is working, and that you can run Docker commands from the AWS
 ## Install the AWS SAM CLI Using the MSI File<a name="serverless-sam-cli-install-windows-msi"></a>
 
 Install the MSI file from one of these locations:
-+ [ 64\-bit](https://github.com/awslabs/aws-sam-cli/releases/download/v0.7.0/AWS_SAM_CLI_64_PY3.msi)
-+ [ 32\-bit](https://github.com/awslabs/aws-sam-cli/releases/download/v0.7.0/AWS_SAM_CLI_32_PY3.msi)
++ [ 64\-bit](https://github.com/awslabs/aws-sam-cli/releases/download/v0.10.0/AWS_SAM_CLI_64_PY3.msi)
++ [ 32\-bit](https://github.com/awslabs/aws-sam-cli/releases/download/v0.10.0/AWS_SAM_CLI_32_PY3.msi)
 
 After completing the installation by using one of these links, open a new command prompt or PowerShell prompt\. You should be able to invoke sam from the command line\.
 


### PR DESCRIPTION
The links to the AWS SAM CLI for Windows installers are out of date and refer to an older version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
