### PR TITLE
Updated Runtimes @ sam init

### DIFF
--- a/doc_source/sam-cli-command-reference-sam-init.md
+++ b/doc_source/sam-cli-command-reference-sam-init.md
@@ -45,7 +45,7 @@ $ sam init --location /path/to/template/folder
 | Option | Description | 
 | --- | --- | 
 |  \-l, \-\-location TEXT | The template location \(Git, Mercurial, HTTP/HTTPS, ZIP, path\)\. | 
-| \-r, \-\-runtime \[python3\.6\| python2\.7\| python\| nodejs6\.10\| nodejs8\.10\| nodejs4\.3\| nodejs\| dotnetcore2\.0\| dotnetcore1\.0\| dotnetcore\| dotnet\| go1\.x\| go\| java8\| java\] | The Lambda runtime of your application\. | 
+| \-r, \-\-runtime \[python3\.7\| python3\.6\| python2\.7\| python\| ruby2\.5\| nodejs6\.10\| nodejs8\.10\| nodejs\| dotnetcore2\.0\| dotnetcore2\.1\| dotnetcore1\.0\| dotnetcore\| dotnet\| go1\.x\| go\| java8\| java\] | The Lambda runtime of your application\. | 
 | \-o, \-\-output\-dir PATH | The location where the initialized application is output\. | 
 | \-n, \-\-name TEXT | The name of your project to be generated as a folder\. | 
 | \-\-no\-input | Disables prompting and accepts default values that are defined in the template configuration\. | 


### PR DESCRIPTION
# What

Hi, I found that "Runtime" is little old.

- https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-init.html

So, I updated runtimes.

# Diff

- Add
    - `python3.7`
    - `ruby2.5`
    - `dotnetcore2.1`
- Delete
    - `nodejs4.3`

# Command

```sh
$ sam --version
SAM CLI, version 0.11.0

$ sam init --help
Usage: sam init [OPTIONS]
  --- snip ---

Options:
  -l, --location TEXT             Template location (git, mercurial, http(s),
                                  zip, path)
  -r, --runtime [python3.7|python3.6|python2.7|python|ruby2.5|nodejs6.10|nodejs8.10|nodejs|dotnetcore2.0|dotnetcore2.1|dotnetcore1.0|dotnetcore|dotnet|go1.x|go|java8|java]
                                  Lambda Runtime of your app
  -o, --output-dir PATH           Where to output the initialized app into
  -n, --name TEXT                 Name of your project to be generated as a
                                  folder
  --no-input                      Disable prompting and accept default values
                                  defined template config
  --debug                         Turn on debug logging to print debug message
                                  generated by SAM CLI.
  -h, --help                      Show this message and exit.
```

# License

I understand it 👍 

>By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Thanks ☀️ 