### PR TITLE
Remove reference to `brew upgrade` in Mac installation instructions

### DIFF
--- a/doc_source/serverless-sam-cli-install-mac.md
+++ b/doc_source/serverless-sam-cli-install-mac.md
@@ -19,10 +19,9 @@ Follow these steps to install the AWS SAM CLI by using Homebrew:
 
 1. To install the Homebrew package manager, follow the instructions on the [ Homebrew website](http://brew.sh/) \.
 
-1. Upgrade Homebrew, and update it to the latest version\.
+1. Update Homebrew\.
 
    ```
-   brew upgrade
    brew update
    ```
 


### PR DESCRIPTION
`brew upgrade` upgrades all installed packages. This is a great way to lose an entire morning when Homebrew updates everything you have installed and something stops working!

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
