### PR TITLE
Document Go Delve debugger API version usage

### DIFF
--- a/doc_source/serverless-sam-cli-using-debugging-golang.md
+++ b/doc_source/serverless-sam-cli-using-debugging-golang.md
@@ -1,6 +1,6 @@
 # Step\-through Debugging Golang Functions Locally<a name="serverless-sam-cli-using-debugging-golang"></a>
 
-Golang function step\-through debugging is slightly different when compared to Node\.js, Java, and Python\. We require [delve](https://github.com/derekparker/delve) as the debugger, and wrap your function with it at runtime\. The debugger is run in headless mode, listening on the debug port\.
+Golang function step\-through debugging is slightly different when compared to Node\.js, Java, and Python\. We require [Delve](https://github.com/go-delve/delve) as the debugger, and wrap your function with it at runtime\. The debugger is run in headless mode, listening on the debug port\.
 
 When you're debugging, you must compile your function in debug mode:
 
@@ -8,26 +8,49 @@ When you're debugging, you must compile your function in debug mode:
 GOARCH=amd64 GOOS=linux go build -gcflags='-N -l' -o <output path> <path to code directory>
 ```
 
-You must compile delve to run in the container and provide its local path with the `--debugger-path` argument\. Build delve locally as follows:
+## Delve debugger
+
+You must compile [Delve](https://github.com/go-delve/delve) to run in the container and provide its local path with the `--debugger-path` argument\. 
+
+Build [Delve](https://github.com/go-delve/delve) locally as follows:
 
 ```
-GOARCH=amd64 GOOS=linux go build -o <delve folder path>/dlv github.com/derekparker/delve/cmd/dlv
+GOARCH=amd64 GOOS=linux go build -o <delve folder path>/dlv github.com/go-delve/delve/cmd/dlv
 ```
 
-**Note**  
+### Delve debugger path 
 The output path needs to end in `/dlv`\. The Docker container expects the dlv binary file to be in the `<delve folder path>`\. If it's not, a mounting issue occurs\.
 
-Then invoke AWS SAM similar to the following:
+**Note**
+
+ >The `--debugger-path` is the path to the directory that contains the dlv binary file that's compiled from the previous code\.
+
+**Example**
+
+Invoke AWS SAM similar to the following:
 
 ```
 sam local start-api -d 5986 --debugger-path <delve folder path>
 ```
 
+### Delve debugger API version 
+
+To run the [Delve](https://github.com/go-delve/delve) debugger with an API verison of your choice, please
+specifiy the desired API verison via an [additional debug argument](serverless-sam-cli-using-debugging-additional-arguments.md) '**-delveAPI**'.
+
 **Note**  
-The `--debugger-path` is the path to the directory that contains the dlv binary file that's compiled from the previous code\.
+> For IDEs such as GoLand, Microsoft Visual Studio Code, etc. It is important to run [Delve](https://github.com/go-delve/delve) in API version **2** mode.
 
-The following is an example launch configuration for Microsoft Visual Studio Code to attach to a debug session\.
+**Example**
 
+See below for an example of how to run [Delve](https://github.com/go-delve/delve)
+in API verison **2** mode.
+```
+sam local start-api -d 5986 --debugger-path <delve folder path> --debug-args "-delveAPI=2"
+```
+
+## Example
+> The following is an example launch configuration for Microsoft Visual Studio Code to attach to a debug session\.
 ```
 {
   "version": "0.2.0",


### PR DESCRIPTION
*Issue [#886](https://github.com/awslabs/aws-sam-cli/issues/886)

Description of changes:
- Update **Debugging Golang Functions** documentation on how to run GO [Delve](https://github.com/go-delve/delve) debugger using API version 2 mode.
- Improve Document structure
- Fix [Delve](https://github.com/go-delve/delve) debugger repository 
- Fix [Delve](https://github.com/go-delve/delve) references to be capitalized

Checklist:
 - [x] Write documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
