### PR TITLE
Grammar: Remove unnecessary comma

### DIFF
--- a/doc_source/serverless-test-and-debug.md
+++ b/doc_source/serverless-test-and-debug.md
@@ -1,6 +1,6 @@
 # Testing and Debugging Serverless Applications<a name="serverless-test-and-debug"></a>
 
-With the AWS SAM command line interface \(CLI\), you can locally test and "step\-through" debug your serverless applications, before uploading your application to the AWS Cloud\. You can verify whether your application is behaving as expected, debug what's wrong, and fix any issues, before going through the steps of packaging and deploying your application\.
+With the AWS SAM command line interface \(CLI\), you can locally test and "step\-through" debug your serverless applications before uploading your application to the AWS Cloud\. You can verify whether your application is behaving as expected, debug what's wrong, and fix any issues, before going through the steps of packaging and deploying your application\.
 
 When you locally invoke a Lambda function in debug mode within the AWS SAM CLI, you can then attach a debugger to it\. With the debugger, you can step through your code line by line, see the values of various variables, and fix issues the same way you would for any other application\.
 


### PR DESCRIPTION
Remove an unneeded comma from the SAM's testing and debugging serverless applications main page. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
