### PR TITLE
Fix small typo

### DIFF
--- a/doc_source/serverless-sam-cli-using-invoke.md
+++ b/doc_source/serverless-sam-cli-using-invoke.md
@@ -37,7 +37,7 @@ You can use the `--env-vars` argument with the `invoke` or `start-api` commands\
   "MyFunction2": {
     "TABLE_NAME": "localtable",
     "STAGE": "dev"
-  },
+  }
 }
 ```
 


### PR DESCRIPTION
The env file isn't readable with this extra `,` as it's not true json



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
