### PR TITLE
add comment because this really burned me

### DIFF
--- a/doc_source/sam-cli-command-reference-sam-build.md
+++ b/doc_source/sam-cli-command-reference-sam-build.md
@@ -36,7 +36,7 @@ $ sam build && sam package --s3-bucket <bucketname>
 
 | Option | Description | 
 | --- | --- | 
-| \-b, \-\-build\-dir DIRECTORY | The path to a folder where the built artifacts are stored\. | 
+| \-b, \-\-build\-dir DIRECTORY | The path to a folder where the built artifacts are stored\.  Note that if you specify a build directory, it will be emptied when `sam build` is ran with this option.  | 
 | \-s, \-\-base\-dir DIRECTORY | Resolves relative paths to the function's source code with respect to this folder\. Use this if the AWS SAM template and your source code aren't in the same enclosing folder\. By default, relative paths are resolved with respect to the template's location\. | 
 | \-u, \-\-use\-container | If your functions depend on packages that have natively compiled dependencies, use this flag to build your function inside an AWS Lambda\-like Docker container\. | 
 | \-m, \-\-manifest PATH | The path to a custom dependency manifest \(ex: package\.json\) to use instead of the default one\. | 


### PR DESCRIPTION
I was in the process of working on a template and wanted to add an **AWS::Serverless::Function** so I use the `sam build` command to build my code with using the `-b ./` command, to my surprise on the second run it complained that the template didn't exist, excuse me?  
Upon closer inspection, anything in the `./` directory was gone.

This would have been nice to know, maybe I would have or would not have read it, but when I go back and see if something said "WARNING THIS HAPPENS" I wouldn't be so bummed, but I came very close to losing a lot of work because this `rm -rf`ed a lot of uncommited changes.

Thanks

```
❯ ls -la
total 8
drwxrwxrwx@  6 bkillian  staff   192 Dec 26 03:51 .
drwxrwxrwx@  9 bkillian  staff   288 Dec 26 03:49 ..
drwxr-xr-x   2 bkillian  staff    64 Dec 26 03:51 test
❯ touch test/test.txt
❯ ls -la test
total 0
drwxr-xr-x  3 bkillian  staff   96 Dec 26 03:52 .
drwxrwxrwx@ 6 bkillian  staff  192 Dec 26 03:51 ..
-rw-r--r--  1 bkillian  staff    0 Dec 26 03:52 test.txt
❯ sam build -b ./test/ -u -t templates/home-unifi.yml --profile trailmix --debug
2019-12-26 03:52:34 Changing event name from creating-client-class.iot-data to creating-client-class.iot-data-plane
...
...
...
Build Failed
Error: PythonPipBuilder:ResolveDependencies - Requirements file not found: /tmp/samcli/source/requirements.txt
❯ ls -la test
total 0
drwxr-xr-x  2 bkillian  staff   64 Dec 26 03:52 .
drwxrwxrwx@ 6 bkillian  staff  192 Dec 26 03:52 ..
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
