### PR TITLE
Correct read_timeout in serverless-sam-cli-using-automated-tests.md

### DIFF
--- a/doc_source/serverless-sam-cli-using-automated-tests.md
+++ b/doc_source/serverless-sam-cli-using-automated-tests.md
@@ -39,7 +39,7 @@ This is how the process works:
            verify=False,
            config=botocore.client.Config(
                signature_version=botocore.UNSIGNED,
-               read_timeout=0,
+               read_timeout=1,
                retries={'max_attempts': 0},
            )
        )


### PR DESCRIPTION
botocore.client.Config with a read_timeout of 0 results in `ValueError: Attempted to set read timeout to 0, but the timeout cannot be set to a value less than or equal to 0.`. Change value to 1 instead.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
