### PR TITLE
Fix command invoking function with event via stdin

### DIFF
--- a/doc_source/serverless-sam-cli-using-invoke.md
+++ b/doc_source/serverless-sam-cli-using-invoke.md
@@ -14,7 +14,7 @@ Examples:
 $ sam local invoke "Ratings" -e event.json
 
 # Invoking function with event via stdin
-$ echo '{"message": "Hey, are you there?" }' | sam local invoke "Ratings"
+$ echo '{"message": "Hey, are you there?" }' | sam local invoke "Ratings" --event -
 
 # For more options
 $ sam local invoke --help


### PR DESCRIPTION
The command mentioned under "Invoking function with event via stdin" is incorrect. Need to pass in the output of the echo to the event.

*Issue #, if available:*

*Description of changes:*
Passing the output of the echo to the event.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
