### PR TITLE
DOCS: Fix length in the unique layer hash

### DIFF
--- a/doc_source/serverless-sam-cli-layers.md
+++ b/doc_source/serverless-sam-cli-layers.md
@@ -38,7 +38,7 @@ Directory name = myLayer-1-926eeb5ff1
 
 **Docker Images tag schema**
 
-To compute the unique layers hash, combine all unique layer names with a delimiter of '\-', take the SHA256 hash, and then take the first 25 characters\.
+To compute the unique layers hash, combine all unique layer names with a delimiter of '\-', take the SHA256 hash, and then take the first 10 characters\.
 
 Example:
 


### PR DESCRIPTION
*Description of changes:*

Fix documentation about how unique layer hash is constructed.

Taking some examples from my `~/.aws-sam/layers-pkg`:
```
imagemagick-678-10-2-42b68250ce
imagemagick-678-10-1-0941bdff73
magick2-1-fc7c7473da
```
All seem to have 10 characters from the hash. I have also validated that 25 is correctly used when the final Docker image hash is computed (combining all the layers), for example: `samcli/lambda:nodejs10.x-831c7136e35ab18065d690192`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
