### PR TITLE
Add note when Role property is omitted

### DIFF
--- a/doc_source/sam-property-function-deploymentpreference.md
+++ b/doc_source/sam-property-function-deploymentpreference.md
@@ -44,7 +44,8 @@ Validation Lambda functions that are run before and after traffic shifting\.
 An IAM role ARN that CodeDeploy will use for traffic shifting\. An IAM role will not be created if this is provided\.  
 *Type*: String  
 *Required*: No  
-*AWS CloudFormation Compatibility*: This property is unique to AWS SAM and doesn't have an AWS CloudFormation equivalent\.
+*AWS CloudFormation Compatibility*: This property is unique to AWS SAM and doesn't have an AWS CloudFormation equivalent\.  
+*Additional Notes*: If this property is not specified the hook function names must begin with the `CodeDeployHook_` prefix, since the role created by SAM only allows *InvokeFunction* on functions named with that prefix\.
 
  `TriggerConfigurations`   <a name="sam-function-deploymentpreference-triggerconfigurations"></a>
 A list of trigger configurations you want to associate with the deployment group\. Used to notify an SNS topic on lifecycle events\.  


### PR DESCRIPTION
Add additional note regarding the requirements on the function name of
the hooks if the role is not specified under DeploymentPreference.

I spent way too many hours trying to figure why I couldn't add a pre-traffic hook to my lambda function resource. It failed during the update of the function alias, when it turned out that the name of the pre-traffic hook lambda function didn't have the expected prefix: `CodeDeployHook_`.

I think it would be good if the documentation would point this out.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
