### PR TITLE
Change serverless-sam-cli-install-linux.md

### DIFF
--- a/doc_source/serverless-sam-cli-install-linux.md
+++ b/doc_source/serverless-sam-cli-install-linux.md
@@ -120,7 +120,7 @@ You should see output like the following on successful installation of Homebrew:
 Follow these steps to install the AWS SAM CLI using Homebrew:
 
 ```
-brew tap aws/tap
+brew tap "aws/tap"
 brew install aws-sam-cli
 ```
 


### PR DESCRIPTION
I did small change on the brew command, I change brew tap aws/tap with brew tap "aws/tap". At least when I run on my machine on Ubuntu Linux I have to put quotes.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
