### PR TITLE
Removing invalid properties

### DIFF
--- a/doc_source/sam-resource-httpapi.md
+++ b/doc_source/sam-resource-httpapi.md
@@ -260,12 +260,10 @@ Resources:
         DestinationArn: !GetAtt AccessLogs.Arn
         Format: $context.requestId
       DefaultRouteSettings:
-        DataTraceEnabled: True
         ThrottlingBurstLimit: 200
       RouteSettings:
         "GET /path":
           ThrottlingBurstLimit: 500 # overridden in HttpApi Event
-          LoggingLevel: ERROR
       StageVariables:
         StageVar: Value
       FailOnWarnings: True


### PR DESCRIPTION
*Description of changes:*
These values were invalid for HTTP APIs and are only valid for WebSocket APIs.
