### PR TITLE
Alternative format for sam local start-api env-vars file

### DIFF
--- a/doc_source/serverless-sam-cli-using-start-api.md
+++ b/doc_source/serverless-sam-cli-using-start-api.md
@@ -69,6 +69,18 @@ You can use the `--env-vars` argument with the `invoke` or `start-api` commands 
 }
 ```
 
+Alternatively, you can define a single `Parameters` entry that sets the enviroment variables for all functions. Note that it is not possible to mix this format with the one outlined above.
+
+```
+{
+  "Parameters": {
+    "TABLE_NAME": "localtable",
+    "BUCKET_NAME": "testBucket",
+    "STAGE": "dev"
+  }
+}
+```
+
 For example, if you save this content in a file named `env.json`, then the following command uses this file to override the included environment variables:
 
 ```


### PR DESCRIPTION
*Issue #:* https://github.com/awslabs/aws-sam-cli/issues/1045

*Description of changes:* According to https://github.com/awslabs/aws-sam-cli/issues/1045, the `sam local start-api` command accepts an `env-vars` file that can be specified in two formats: the standard format, as currently described in the documentation, and the Cloudformation format, which uses a single `Parameters` entry for all functions. This change updates the documentation to reflect both formats.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
