### PR TITLE
Update building custom runtime

### DIFF
--- a/doc_source/building-custom-runtimes.md
+++ b/doc_source/building-custom-runtimes.md
@@ -27,9 +27,9 @@ Resources:
 The following `makefile` contains the build target and commands that will be executed\.
 
 ```
-    build-HelloRustFunction:
-    	cargo build --release --target x86_64-unknown-linux-musl
-    	cp ./target/x86_64-unknown-linux-musl/release/bootstrap $(ARTIFACTS_DIR)
+build-HelloRustFunction:
+  cargo build --release --target x86_64-unknown-linux-musl
+  cp ./target/x86_64-unknown-linux-musl/release/bootstrap $(ARTIFACTS_DIR)
 ```
 
 For more information about setting up your development environment in order to execute the `cargo build` command in the previous `makefile`, see the [Rust Runtime for AWS Lambda](https://aws.amazon.com/blogs/opensource/rust-runtime-for-aws-lambda/) blog post\.


### PR DESCRIPTION
Extra space in the RUST makefile example was causing issues when copied and pasted. Also converted spaces to tabs for makefile.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
