### PR TITLE
Remve local path examples from --location usage

### DIFF
--- a/doc_source/sam-cli-command-reference-sam-init.md
+++ b/doc_source/sam-cli-command-reference-sam-init.md
@@ -36,10 +36,6 @@ sam init --location hg+ssh://hg@bitbucket.org/repo/template-name
 sam init --location /path/to/template.zip
 
 sam init --location https://example.com/path/to/template.zip
-
-# Initializes a new SAM project using custom template in a local path
-
-sam init --location /path/to/template/folder
 ```
 
 **Options:**
@@ -50,7 +46,7 @@ sam init --location /path/to/template/folder
 | Option | Description | 
 | --- | --- | 
 | \-\-no\-interactive | Disable interactive prompting for init parameters, and fail if any required values are missing\. | 
-|  \-l, \-\-location TEXT |  The template or application location \(Git, Mercurial, HTTP/HTTPS, ZIP, path\)\. This parameter is required if `--no-interactive` is specified and `--runtime`, `--name`, and `--app-template` are not provided\. For Git repositories, you must use location of the root of the repository\.  | 
+|  \-l, \-\-location TEXT |  The template or application location \(Git, Mercurial, HTTP/HTTPS, ZIP\)\. This parameter is required if `--no-interactive` is specified and `--runtime`, `--name`, and `--app-template` are not provided\. For Git repositories, you must use location of the root of the repository\.  | 
 | \-r, \-\-runtime \[python2\.7 \| nodejs6\.10 \| ruby2\.5 \| java8 \| python3\.7 \| nodejs8\.10 \| dotnetcore2\.0 \| nodejs10\.x \| dotnetcore2\.1 \| dotnetcore1\.0 \| python3\.6 \| go1\.x\] |  The Lambda runtime of your application\. This parameter is required if `--no-interactive` is specified and `--location` is not provided\.  | 
 | \-d, \-\-dependency\-manager \[gradle \| mod \| maven \| bundler \| npm \| cli\-package \| pip\] | Dependency manager of your Lambda runtime | 
 | \-o, \-\-output\-dir PATH | The location where the initialized application is output\. | 


### PR DESCRIPTION
SAM doesn't support a local filesystem path for `--location` anymore.

See https://github.com/awslabs/aws-sam-cli/blob/develop/samcli/lib/init/arbitrary_project.py#L41

*Description of changes:*

The SAM CLI doesn't support passing a local filesystem path to the `--location` option during `sam init`. This PR removes references to the path option.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
