### PR TITLE
stateMachineName should be StateMachineName

### DIFF
--- a/doc_source/serverless-policy-template-list.md
+++ b/doc_source/serverless-policy-template-list.md
@@ -1587,7 +1587,7 @@ Gives permission to start a Step Functions state machine execution\.
               "Fn::Sub": [
                 "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${stateMachineName}",
                 {
-                  "stateMachineName": {
+                  "StateMachineName": {
                     "Ref": "StateMachineName"
                   }
                 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`stateMachineName` causes cloudformation errors. `StateMachineName` is the correct word.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
