### PR TITLE
Update serverless-sam-cli-install-mac.md

### DIFF
--- a/doc_source/serverless-sam-cli-install-mac.md
+++ b/doc_source/serverless-sam-cli-install-mac.md
@@ -90,7 +90,7 @@ You should see output like the following after successful installation of the AW
 
 ```
  
- SAM CLI, version 0.52.0
+ SAM CLI, version 1.0.0
 ```
 
 You're now ready to start development\.


### PR DESCRIPTION
Update SAM CLI version to 1.0.0, as this is the default version now.

*Issue #, if available:*
NA

*Description of changes:*
Updated the CLI output of sam --version, as now the default version for mac is 1.0.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
