### PR TITLE
Updated Homebrew installer URL & versions outputs

### DIFF
--- a/doc_source/serverless-sam-cli-install-mac.md
+++ b/doc_source/serverless-sam-cli-install-mac.md
@@ -54,7 +54,7 @@ To install Homebrew, you must first install Git\. For more information about Git
 Once you have successfully installed Git, run the following to install Homebrew, making sure to follow the prompts:
 
 ```
-/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 ```
 
 Verify that Homebrew is installed:

--- a/doc_source/serverless-sam-cli-install-mac.md
+++ b/doc_source/serverless-sam-cli-install-mac.md
@@ -67,8 +67,9 @@ You should see output like the following on successful installation of Homebrew:
 
 ```
  
- Homebrew 2.1.6 
- Homebrew/homebrew-core (git revision ef21; last commit 2019-06-19)
+Homebrew 2.4.11
+Homebrew/homebrew-core (git revision 54246b; last commit 2020-08-13)
+Homebrew/homebrew-cask (git revision 4fd7ce; last commit 2020-08-14)
 ```
 
 ## Step 5: Install the AWS SAM CLI<a name="serverless-sam-cli-install-mac-sam-cli"></a>
@@ -90,7 +91,7 @@ You should see output like the following after successful installation of the AW
 
 ```
  
- SAM CLI, version 1.0.0
+SAM CLI, version 1.1.0
 ```
 
 You're now ready to start development\.


### PR DESCRIPTION
Updated Homebrew installer URL from the deprecated ruby installer.

*Issue #, if available:*

*Description of changes:*
Updated Homebrew installer URL from the deprecated ruby installer.

```
$ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"                                                  ✔  at 19:54:26 
Warning: The Ruby Homebrew installer is now deprecated and has been rewritten in
Bash. Please migrate to the following command:
  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
