### PR TITLE
Update python debug readme to use SAM Build and Debugpy

### DIFF
--- a/doc_source/serverless-sam-cli-using-debugging-python.md
+++ b/doc_source/serverless-sam-cli-using-debugging-python.md
@@ -2,38 +2,35 @@
 
 Python step\-through debugging requires you to enable remote debugging in your Lambda function code\. This is a two\-step process:
 
-1. Install the [ptvsd library](https://pypi.org/project/ptvsd/) and enable it within your code\.
+1. Install the [debugpy library](https://pypi.org/project/debugpy/) and enable it within your code\.
 
-1. Configure your IDE to connect to the debugger that you configured for your function\.
+2. Configure your IDE to connect to the debugger that you configured for your function\.
 
-Because this might be your first time using the AWS SAM CLI, start with a boilerplate Python application, and install both the application's dependencies and ptvsd:
+If this is your first time using the AWS SAM CLI, start with a boilerplate Python application.
 
 ```
-sam init --runtime python3.6 --name python-debugging
+sam init --runtime python3.7 --name python-debugging
 cd python-debugging/
-
-# Install dependencies of our boilerplate app
-pip install -r hello_world/requirements.txt -t hello_world/build/
-
-# Install ptvsd library for step through debugging
-pip install ptvsd -t hello_world/build/
-
-cp hello_world/app.py hello_world/build/
 ```
 
-## Ptvsd Configuration<a name="serverless-sam-cli-using-debugging-python-ptvsd"></a>
+## DebugPy Configuration<a name="serverless-sam-cli-using-debugging-python-ptvsd"></a>
 
-Next, you need to enable ptvsd within your code\. To do this, open `hello_world/build/app.py`, and add the following ptvsd specifics:
+Because SAM runs the code in a docker container, we will need to use a debugging library to listen for a debugging connection. Add `debugpy` to the `hello_world/requirements.txt` file.
+
+Next, you need to enable ptvsd within your code\. To do this, open `hello_world/build/app.py`, and add the following code:
 
 ```
-import ptvsd
+import debugpy
 
-# Enable ptvsd on 0.0.0.0 address and on port 5890 that we'll connect later with our IDE
-ptvsd.enable_attach(address=('0.0.0.0', 5890), redirect_output=True)
-ptvsd.wait_for_attach()
+# Enable debugpy on all network interfaces within the docker containter (0.0.0.0) and on port 5890 that we'll connect to later with our IDE
+debugpy.listen(("0.0.0.0",5678))
+# Pause code execution until a debugger is connected
+debugpy.wait_for_client()
 ```
 
-Use `0.0.0.0` instead of `localhost` for listening across all network interfaces\. `5890` is the debugging port that you want to use\.
+Use `0.0.0.0` instead of `localhost` for listening across all network interfaces since port forwarding to the Docker container will not be picked up if you are listening on `localhost`\. `5890` is the debugging port that you want to use\.
+
+Now run `sam build` to download the dependencies and build a code package. This will create a folder `/.aws-sam/build/` which contains the lambda code and all of the dependencies found in `requirements.txt`.
 
 ## Microsoft Visual Studio Code<a name="serverless-sam-cli-using-debugging-python-vs-code"></a>
 
@@ -60,7 +57,7 @@ To set up Microsoft Visual Studio Code for debugging with the AWS SAM CLI, use t
            "host": "localhost",
            "pathMappings": [
                {
-                   "localRoot": "${workspaceFolder}/hello_world/build",
+                   "localRoot": "${workspaceFolder}/.aws-sam/build",
                    "remoteRoot": "/var/task"
                }
            ]
@@ -69,26 +66,27 @@ To set up Microsoft Visual Studio Code for debugging with the AWS SAM CLI, use t
  }
 ```
 
-For Microsoft Visual Studio Code, the property `localRoot` under the `pathMappings` key is important\. There are two reasons that help explain this setup:
-+ **localRoot**: This path is to be mounted in the Docker container, and needs to have both the application and dependencies at the root level\.
-+ **workspaceFolder**: This path is the absolute path where the Microsoft Visual Studio Code instance was opened\.
+For Microsoft Visual Studio Code, the property `localRoot` under the `pathMappings` key is important\.
++ **localRoot**: This is the path to the "local" code that needs to be an exactly copy of the code running "remoptely" (in the Docker container). `/.aws-sam/build` is the default that SAM builds to and mounts from, so that is what we use here\.
++ **remoteRoot**: this is the location in the SAM-run docker container where the code is located.
++ **workspaceFolder**: This path variable represents the absolute path where the Microsoft Visual Studio Code instance was opened\.
 
 If you opened Microsoft Visual Studio Code in a different location other than `python-debugging/`, you need to replace it with the absolute path where `python-debugging/` is located\.
 
-After the Microsoft Visual Studio Code debugger configuration is complete, make sure to add a breakpoint anywhere you want to in `hello_world/build/app.py`, and then proceed as follows:
+After the Microsoft Visual Studio Code debugger configuration is complete, make sure to add a breakpoint anywhere you want to in the built copy of your code at`.aws-sam/build/HelloWorldFunction/app.py`, and then proceed as follows:
 
-1. Run the AWS SAM CLI to invoke your function\.
-
-1. Send a request to the URL to invoke the function and initialize ptvsd code execution\.
-
-1. Start the debugger within Microsoft Visual Studio Code\.
+1. Run the AWS SAM CLI to invoke your function with a `-d` option to tell SAM what port you will be listening on so that is knows to set up port forwarding\.
 
 ```
-# Remember to hit the URL before starting the debugger in Microsoft Visual Studio Code
 sam local start-api -d 5890
 
 # OR
 
-# Change HelloWorldFunction to reflect the logical name found in template.yaml
-sam local generate-event apigateway aws-proxy | sam local invoke HelloWorldFunction -d 5890
+sam local invoke HelloWorldFunction --event events/event.json --d 5890 
 ```
+
+2. If using `start-api`, send a request to the URL to invoke the function and initialize debugpy code execution\.
+
+3. Start the debugger within Microsoft Visual Studio Code using the "SAM CLI Python Hello World" configuration\.
+
+NOTE: Make sure your breakpoints are in the built version of your code, not the editable version of your code. You will need to rerun `sam build` any time you make changes to the code so that they are propigated into the build folder, which you should never edit directly.


### PR DESCRIPTION
This readme appears to be outdated. No devs on our team have been able to get debugging working as described here. There is also an [open issue](https://github.com/awsdocs/aws-sam-developer-guide/issues/8) since last year regarding this documentation. 

The manual build steps seem to be the main source of confusion. I have updated the instructions to use `sam build` instead, which simplifies things a lot while also encouraging proper usage of the SAM cli. 

While it wasn't causing an problems, I also updated from `ptvsd` to the more modern `debugpy` while I was in there. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
