### PR TITLE
Update sam installation in linux

### DIFF
--- a/doc_source/serverless-sam-cli-install-linux.md
+++ b/doc_source/serverless-sam-cli-install-linux.md
@@ -97,7 +97,7 @@ To install Homebrew, you must first install Git\. For more information about Git
 Once you have successfully installed Git, run the following to install Homebrew:
 
 ```
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/Linuxbrew/install/master/install.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 ```
 
 Next, add Homebrew to your PATH by running the following commands\. These commands work on all major flavors of Linux by adding either `~/.profile` on Debian/Ubuntu or `~/.bash_profile` on CentOS/Fedora/RedHat:


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

Brew install command is outdated. In brew.sh the new command is:

`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"`

Reference: https://brew.sh/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
