### PR TITLE
Adjust casing for "Invoking functions locally" page

### DIFF
--- a/doc_source/index.md
+++ b/doc_source/index.md
@@ -121,7 +121,7 @@ Amazon's trademarks and trade dress may not be used in
    + [Building layers](building-layers.md)
    + [Building custom runtimes](building-custom-runtimes.md)
 + [Testing and debugging serverless applications](serverless-test-and-debug.md)
-   + [Invoking Functions Locally](serverless-sam-cli-using-invoke.md)
+   + [Invoking functions locally](serverless-sam-cli-using-invoke.md)
    + [Running API Gateway locally](serverless-sam-cli-using-start-api.md)
    + [Integrating with automated tests](serverless-sam-cli-using-automated-tests.md)
    + [Generating sample event payloads](serverless-sam-cli-using-generate-event.md)

--- a/doc_source/serverless-sam-cli-using-invoke.md
+++ b/doc_source/serverless-sam-cli-using-invoke.md
@@ -1,4 +1,4 @@
-# Invoking Functions Locally<a name="serverless-sam-cli-using-invoke"></a>
+# Invoking functions locally<a name="serverless-sam-cli-using-invoke"></a>
 
 You can invoke your function locally by using the `sam local invoke` command and providing its function logical ID and an event file\. Alternatively, `sam local invoke` also accepts `stdin` as an event\.
 


### PR DESCRIPTION
*Description of changes:*

The casing for the "Invoking functions locally" page in the "Testing and debugging" section was inconsistent with the rest of the document.  This small change corrects that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
