### PR TITLE
Correct typo for DockerContext in sam cli build documentation

### DIFF
--- a/doc_source/serverless-sam-cli-using-build.md
+++ b/doc_source/serverless-sam-cli-using-build.md
@@ -22,7 +22,7 @@ See the Examples section later in this topic for an example of building a \.zip 
 
 To build your serverless application as a container image, declare `PackageType: Image` for your serverless function\. You must also declare the `Metadata` resource attribute with the following entries:
 + `Dockerfile`: The name of the Dockerfile associated with the Lambda function
-+ `DockerContent`: The location of the Dockerfile
++ `DockerContext`: The location of the Dockerfile
 + `DockerTag`: Optional tag to apply to the built image
 + `DockerBuildArgs`: Build arguments for the build
 


### PR DESCRIPTION
Reference to sam build cli key it is looking for:
https://github.com/aws/aws-sam-cli/blob/master/samcli/lib/build/app_builder.py#L238

*Issue #, if available:* N/A

*Description of changes:*

Correct a typo in the new Lambda Container Image Support SAM CLI documentation. Was misspelled as `DockerContent`, instead of `DockerContext`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
