### PR TITLE
Add necessary lambda permission for AGW to invoke auth lambda

### DIFF
--- a/doc_source/serverless-controlling-access-to-apis-lambda-authorizer.md
+++ b/doc_source/serverless-controlling-access-to-apis-lambda-authorizer.md
@@ -135,4 +135,12 @@ Resources:
       CodeUri: ./src
       Handler: authorizer.handler
       Runtime: nodejs12.x
+
+  MyAuthFunctionApiGatewayInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !GetAtt MyAuthFunction.Arn
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${MyApi}/*"
 ```


### PR DESCRIPTION
*Description of changes:*

API Gateway needs permission to invoke the Auth Lambda. This example had no permission granted to AGW to enable that invocation. This would lead to HTTP 500 errors when running the example.

Added the AWS::Lambda::Permission. I have not confirmed if the AWS::Serverless::Api examples also need this addition.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
