### PR TITLE
Fix two typos in policy templates - serverless-policy-template-list.md

### DIFF
--- a/doc_source/serverless-policy-template-list.md
+++ b/doc_source/serverless-policy-template-list.md
@@ -444,9 +444,7 @@ Gives permission to describe Amazon Machine Images \(AMIs\)\.
             "Action": [
               "ec2:DescribeImages"
             ],
-            "Resource": {
-              "*"
-            }
+            "Resource": "*"
           }
         ]
 ```
@@ -1166,7 +1164,7 @@ Gives permission to add, delete, and search faces in an Amazon Rekognition colle
               }
             ]
           }
-        ]
+        }]
 ```
 
 ## RekognitionFacesPolicy<a name="rekognition-faces-policy"></a>


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* Found two typos in the policies, fixed, and tested.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
