### PR TITLE
Add PartiQL support to DynamoDB policy templates

### DIFF
--- a/doc_source/serverless-policy-template-list.md
+++ b/doc_source/serverless-policy-template-list.md
@@ -124,7 +124,11 @@ Gives create, read, update, and delete permissions to an Amazon DynamoDB table\.
               "dynamodb:BatchWriteItem",
               "dynamodb:BatchGetItem",
               "dynamodb:DescribeTable",
-              "dynamodb:ConditionCheckItem"
+              "dynamodb:ConditionCheckItem",
+              "dynamodb:PartiQLSelect",
+              "dynamodb:PartiQLUpdate",
+              "dynamodb:PartiQLInsert",
+              "dynamodb:PartiQLDelete"
             ],
             "Resource": [
               {
@@ -165,7 +169,8 @@ Gives read\-only permission to a DynamoDB table\.
               "dynamodb:Scan",
               "dynamodb:Query",
               "dynamodb:BatchGetItem",
-              "dynamodb:DescribeTable"
+              "dynamodb:DescribeTable",
+              "dynamodb:PartiQLSelect"
             ],
             "Resource": [
               {
@@ -204,7 +209,9 @@ Gives write\-only permission to a DynamoDB table\.
             "Action": [
               "dynamodb:PutItem",
               "dynamodb:UpdateItem",
-              "dynamodb:BatchWriteItem"
+              "dynamodb:BatchWriteItem",
+              "dynamodb:PartiQLUpdate",
+              "dynamodb:PartiQLInsert"
             ],
             "Resource": [
               {


### PR DESCRIPTION
Add PartiQL support to DynamoDB policy templates to document aws/serverless-application-model#2289

*Issue #, if available:*

Issue aws/serverless-application-model#2288
Pull request aws/serverless-application-model#2289

*Description of changes:*

To the policy `DynamoDBCrudPolicy`, add:
 * `dynamodb:PartiQLSelect`
 * `dynamodb:PartiQLUpdate`
 * `dynamodb:PartiQLInsert`
 * `dynamodb:PartiQLDelete`

To the policy `DynamoDBReadPolicy`, add:
 * `dynamodb:PartiQLSelect`

To the policy `DynamoDBWritePolicy`, add:
 * `dynamodb:PartiQLUpdate`
 * `dynamodb:PartiQLInsert`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
