### PR TITLE
Fix docs: add missing AcmGetCertificatePolicy to policy template list

### DIFF
--- a/doc_source/serverless-policy-template-list.md
+++ b/doc_source/serverless-policy-template-list.md
@@ -1096,6 +1096,31 @@ Gives permission to get the secret value for the specified AWS Secrets Manager s
         ]
 ```
 
+## AcmGetCertificatePolicy<a name="acm-get-certificate-policy"></a>
+
+Gives permission to get a certificate and its certificate chain from ACM\.
+
+```
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "acm:GetCertificate"
+            ],
+            "Resource": {
+              "Fn::Sub": [
+                "${certificateArn}",
+                {
+                  "certificateArn": {
+                    "Ref": "CertificateArn"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+```
+
 ## CodePipelineReadOnlyPolicy<a name="code-pipeline-readonly-policy"></a>
 
 Gives read permission to get details about a CodePipeline pipeline\.


### PR DESCRIPTION
The policy `AcmGetCertificatePolicy` is available since release [v1.35.0](https://github.com/aws/serverless-application-model/releases/tag/v1.35.0) (2021-03-12). However, it is missing from the [policy template list](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-policy-template-list.html) documentation.

Related issue and PR: https://github.com/aws/serverless-application-model/issues/1854, https://github.com/aws/serverless-application-model/pull/1853).

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
