### PR TITLE
Update serverless-controlling-access-to-apis-cognito-user-pool.md

### DIFF
--- a/doc_source/serverless-controlling-access-to-apis-cognito-user-pool.md
+++ b/doc_source/serverless-controlling-access-to-apis-cognito-user-pool.md
@@ -13,6 +13,7 @@ Resources:
       Cors: "'*'"
       Auth:
         DefaultAuthorizer: MyCognitoAuthorizer
+        AddDefaultAuthorizerToCorsPreflight: false
         Authorizers:
           MyCognitoAuthorizer:
             UserPoolArn: !GetAtt MyCognitoUserPool.Arn


### PR DESCRIPTION
Make sure that this actually works as the omission of 'AddDefaultAuthorizerToCorsPreflight: false' will cause the cognito authorizer to be applied to the cors endpoints which makes them unusable.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
