### PR TITLE
Update cloudformation limits

### DIFF
--- a/doc_source/serverless-sam-template-nested-applications.md
+++ b/doc_source/serverless-sam-template-nested-applications.md
@@ -13,8 +13,8 @@ You can define nested applications from the following two sources:
 See the following sections for details on how to use AWS SAM to define both of these types of nested applications in your serverless application\.
 
 **Note**  
-The maximum number of applications that can be nested in a serverless application is 200\.  
-The maximum number of parameters a nested application can have is 60\.
+The maximum number of applications that can be nested in a serverless application is 500\.  
+The maximum number of parameters a nested application can have is 200\.
 
 ## Defining a nested application from the AWS Serverless Application Repository<a name="serverless-sam-template-nested-applications-how-to-serverlessrepo"></a>
 


### PR DESCRIPTION
The description of the limitations not match with the cloudformation limits.

*Description of changes:*

Cloudformation limits are 200 parameters and 500 resources.
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html
https://github.com/awsdocs/aws-cloudformation-user-guide/commit/4c40f339a30f64ff2d33a9807bbd57b544956250#diff-6a66fdde48dfcf9f4e5b77524a17f8100213f95c97fae1eb35f51895ef84f8ae

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
