### PR TITLE
Update serverless-sam-cli-using-debugging.md

### DIFF
--- a/doc_source/serverless-sam-cli-using-debugging.md
+++ b/doc_source/serverless-sam-cli-using-debugging.md
@@ -34,7 +34,7 @@ There are a variety AWS Toolkits that work with different combinations of IDEs a
 
 ## Running AWS SAM locally in debug mode<a name="serverless-sam-cli-running-locally"></a>
 
-In addition to integrating with AWS Toolkits, you can also run AWS SAM in "debug mode" to attach to third\-party debuggers like [ptvsd](https://pypi.org/project/ptvsd/) or [delve](https://github.com/go-delve/delve)\.
+In addition to integrating with AWS Toolkits, you can also run AWS SAM in "debug mode" to attach to third\-party debuggers like [debugpy](https://pypi.org/project/debugpy/) or [delve](https://github.com/go-delve/delve)\.
 
 To run AWS SAM in debug mode, use commands [sam local invoke](sam-cli-command-reference-sam-local-invoke.md) or [sam local start\-api](sam-cli-command-reference-sam-local-start-api.md) with the `--debug-port` or `-d` option\.
 


### PR DESCRIPTION
PTVSD has been deprecated. [debugpy](https://pypi.org/project/debugpy/) is a replacement based on a 5.x branch of ptvsd. See https://github.com/Microsoft/ptvsd/
