### PR TITLE
Document the fact that `Dockerfile` can be in nested subfolder within `DockerContext`

### DIFF
--- a/doc_source/serverless-sam-cli-using-build.md
+++ b/doc_source/serverless-sam-cli-using-build.md
@@ -37,10 +37,10 @@ For additional examples of building a \.zip file archive application, see the Ex
 To build your serverless application as a container image, declare `PackageType: Image` for your serverless function\. You must also declare the `Metadata` resource attribute with the following entries:
 
 `Dockerfile`  
-The name of the Dockerfile associated with the Lambda function\.
+Path to the `Dockerfile` associated with the Lambda function (relative to `DockerContext`)\.
 
 `DockerContext`  
-The location of the Dockerfile\.
+Directory that contains the `Dockerfile`. Typically `Dockerfile` is a direct child of `Dockercontext`, but it can also be in a nested directory\.
 
 `DockerTag`  
 \(Optional\) A tag to apply to the built image\.


### PR DESCRIPTION
*Description of changes:*

Currently the `SAM CLI` user guide implies that `Dockerfile` must be a direct child of `DockerContext`. 

This is often the case, but the code also allows `Dockerfile` to be in a nested subfolder within `DockerContext`.  

This capability of the SAM CLI is useful because...

Say you have a folder structure like:

```
project-root
└───application
│   └───runtime
│       │   Dockerfile
│       │   app.py
│       │   requirements.txt
└───another_application
│   └───runtime
│       │   Dockerfile
│       │   app.py
│       │   requirements.txt
└───shared_code
    │   shared.py

```

There are 2 apps in the repo - in folders `application` and `another_application`

Each app contains a lambda.

The 2 lambdas share some common code, which is in a folder called `shared_code`

In each lambda's `Dockerfile`, we need to copy the `shared_code` module into the container.

Therefore, when we are building each lambda's container, we need to set the `DockerContext` to be the root folder of the repo `/project-root`, because this means `/project-root/shared_code` will be accessible when we build the container.

The `DockerContext` cannot be the folder that contains `Dockerfile`. I.e. it cannot be `project-root/application/runtime` - because the `/project-root/shared_code` folder would not be readable while the container is being built.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
