### PR TITLE
Removed out dated info from HttpApi document.

### DIFF
--- a/doc_source/sam-resource-httpapi.md
+++ b/doc_source/sam-resource-httpapi.md
@@ -182,16 +182,6 @@ Properties:
           audience:
             - MyApi
         IdentitySource: "$request.querystring.param"
-      OpenIdAuth:
-        AuthorizationScopes:
-          - scope1
-          - scope2
-        OpenIdConnectUrl: "https://www.example.com/v1/connect/oidc/.well-known/openid-configuration"
-        JwtConfiguration:
-          issuer: "https://www.example.com/v1/connect/oidc"
-          audience:
-            - MyApi
-        IdentitySource: "$request.querystring.param"
 ```
 
 ### HttpApi with OpenAPI definition<a name="sam-resource-httpapi--examples--httpapi-with-openapi-definition"></a>


### PR DESCRIPTION

#163 

Removed `OpenIdConnectUrl` from the example as it is no longer being supported. 
Please refer #163 for more details.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
