### PR TITLE
Include Connector attribute in description

### DIFF
--- a/doc_source/sam-permissions.md
+++ b/doc_source/sam-permissions.md
@@ -10,7 +10,7 @@ The AWS Serverless Application Model \(AWS SAM\) provides two options that simpl
 
 ## AWS SAM connectors<a name="sam-permissions-intro-connectors"></a>
 
-Connectors are an AWS SAM abstract resource type, identified as `AWS::Serverless::Connector`, that can be defined in your AWS SAM templates to grant `Read` and `Write` access of data and events from a supported AWS resource to another\. To learn more about AWS SAM connectors, see [Managing resource permissions with AWS SAM connectors](managing-permissions-connectors.md)\.
+Connectors are a way to grant model the permissions needed for two services in your SAM template to successfully interact. Connectors are defined with the `Connectors` resource attribute or as an AWS SAM abstract resource type, identified as `AWS::Serverless::Connector`. SAM connectors can be used to grant `Read` and `Write` access of data and events from a supported AWS resource to another\. To learn more about AWS SAM connectors, see [Managing resource permissions with AWS SAM connectors](managing-permissions-connectors.md)\.
 
 ## AWS SAM policy templates<a name="sam-permissions-intro-policy-templates"></a>
 


### PR DESCRIPTION
Previous to this commit, the SAM connector description did not include any mention of the ability to define connectors as a Connector resource attribute. This commit rephrases the description to explain to readers they can use the Connector resource attribute or the resource type definition.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
