### PR TITLE
Add new SSMParameterWithSlashPrefixReadPolicy policy to the docs

### DIFF
--- a/doc_source/serverless-policy-template-list.md
+++ b/doc_source/serverless-policy-template-list.md
@@ -2121,7 +2121,7 @@ Gives permission to send message to an Amazon SQS queue\.
 
 ## SSMParameterReadPolicy<a name="ssm-parameter-read-policy"></a>
 
-Gives permission to access a parameters from an Amazon EC2 Systems Manager \(SSM\) parameter store to load secrets in this account\. Use when parameter name doesn't have slash prefix\.
+Gives permission to access a parameter from an Amazon EC2 Systems Manager \(SSM\) parameter store to load secrets in this account\. Use when parameter name doesn't have slash prefix\.
 
 **Note**  
 If you are not using default key, you will also need the `KMSDecryptPolicy` policy\.
@@ -2158,7 +2158,7 @@ If you are not using default key, you will also need the `KMSDecryptPolicy` poli
 
 ## SSMParameterWithSlashPrefixReadPolicy<a name="ssm-parameter-with-slash-prefix-read-policy"></a>
 
-Gives permission to access a parameters from an Amazon EC2 Systems Manager \(SSM\) parameter store to load secrets in this account\. Use when parameter name has slash prefix\.
+Gives permission to access a parameter from an Amazon EC2 Systems Manager \(SSM\) parameter store to load secrets in this account\. Use when parameter name has slash prefix\.
 
 **Note**  
 If you are not using default key, you will also need the `KMSDecryptPolicy` policy\.

--- a/doc_source/serverless-policy-template-list.md
+++ b/doc_source/serverless-policy-template-list.md
@@ -74,6 +74,7 @@ The following are the available policy templates, along with the permissions tha
 + [SQSPollerPolicy](#sqs-poller-policy)
 + [SQSSendMessagePolicy](#sqs-send-message-policy)
 + [SSMParameterReadPolicy](#ssm-parameter-read-policy)
++ [SSMParameterWithSlashPrefixReadPolicy](#ssm-parameter-with-slash-prefix-read-policy)
 + [StepFunctionsExecutionPolicy](#stepfunctions-execution-policy)
 + [TextractDetectAnalyzePolicy](#textract-detect-analyze-policy)
 + [TextractGetResultPolicy](#textract-get-result-policy)
@@ -2120,7 +2121,7 @@ Gives permission to send message to an Amazon SQS queue\.
 
 ## SSMParameterReadPolicy<a name="ssm-parameter-read-policy"></a>
 
-Gives permission to access a parameters from an Amazon EC2 Systems Manager \(SSM\) parameter store to load secrets in this account\.
+Gives permission to access a parameters from an Amazon EC2 Systems Manager \(SSM\) parameter store to load secrets in this account\. Use when parameter name doesn't have slash prefix\.
 
 **Note**  
 If you are not using default key, you will also need the `KMSDecryptPolicy` policy\.
@@ -2144,6 +2145,43 @@ If you are not using default key, you will also need the `KMSDecryptPolicy` poli
             "Resource": {
               "Fn::Sub": [
                 "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${parameterName}",
+                {
+                  "parameterName": {
+                    "Ref": "ParameterName"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+```
+
+## SSMParameterWithSlashPrefixReadPolicy<a name="ssm-parameter-with-slash-prefix-read-policy"></a>
+
+Gives permission to access a parameters from an Amazon EC2 Systems Manager \(SSM\) parameter store to load secrets in this account\. Use when parameter name has slash prefix\.
+
+**Note**  
+If you are not using default key, you will also need the `KMSDecryptPolicy` policy\.
+
+```
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "ssm:DescribeParameters"
+            ],
+            "Resource": "*"
+          },
+          {
+            "Effect": "Allow",
+            "Action": [
+              "ssm:GetParameters",
+              "ssm:GetParameter",
+              "ssm:GetParametersByPath"
+            ],
+            "Resource": {
+              "Fn::Sub": [
+                "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter${parameterName}",
                 {
                   "parameterName": {
                     "Ref": "ParameterName"

--- a/doc_source/serverless-policy-templates.md
+++ b/doc_source/serverless-policy-templates.md
@@ -142,7 +142,8 @@ The following is a table of the available policy templates\.
 | [SNSPublishMessagePolicy](serverless-policy-template-list.md#sqs-publish-message-policy) | Gives permission to publish a message to an Amazon Simple Notification Service \(Amazon SNS\) topic\. | 
 | [SQSPollerPolicy](serverless-policy-template-list.md#sqs-poller-policy) | Gives permission to poll an Amazon Simple Queue Service \(Amazon SQS\) queue\. | 
 | [SQSSendMessagePolicy](serverless-policy-template-list.md#sqs-send-message-policy) | Gives permission to send message to an Amazon SQS queue\. | 
-| [SSMParameterReadPolicy](serverless-policy-template-list.md#ssm-parameter-read-policy) | Gives permission to access a parameters from an Amazon EC2 Systems Manager \(SSM\) parameter store to load secrets in this account\. | 
+| [SSMParameterReadPolicy](serverless-policy-template-list.md#ssm-parameter-read-policy) | Gives permission to access a parameters from an Amazon EC2 Systems Manager \(SSM\) parameter store to load secrets in this account\. Used when parameter name doesn't have slash prefix\. | 
+| [SSMParameterWithSlashPrefixReadPolicy](serverless-policy-template-list.md#ssm-parameter-read-policy) | Gives permission to access a parameters from an Amazon EC2 Systems Manager \(SSM\) parameter store to load secrets in this account\. Used when parameter name has slash prefix\. | 
 | [StepFunctionsExecutionPolicy](serverless-policy-template-list.md#stepfunctions-execution-policy) | Gives permission to start a Step Functions state machine execution\. | 
 | [TextractDetectAnalyzePolicy](serverless-policy-template-list.md#textract-detect-analyze-policy) | Gives access to detect and analyze documents with Amazon Textract\. | 
 | [TextractGetResultPolicy](serverless-policy-template-list.md#textract-get-result-policy) | Gives access to get detected and analyzed documents from Amazon Textract\. | 


### PR DESCRIPTION
*Issue #, if available:*

Doc update for this [PR](https://github.com/aws/serverless-application-model/pull/2693) which adds a new SSM policy.

*Description of changes:*

The new policy is basically the same as the existing `SSMParameterReadPolicy` but without the `/` before `${parameterName}` in `arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${parameterName}` (we couldn't change the policy directly as that could cause compatibility issues).

This change isn't out in all regions yet but I was hoping to get your approval on this then merge once the change is fully in production. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
