### PR TITLE
Fix incorrect resource reference in JWT auth example

### DIFF
--- a/doc_source/serverless-controlling-access-to-apis-oauth2-authorizer.md
+++ b/doc_source/serverless-controlling-access-to-apis-oauth2-authorizer.md
@@ -29,7 +29,7 @@ Resources:
       Events:
         GetRoot:
           Properties:
-            ApiId: MyApi
+            ApiId: !Ref MyApi
             Method: get
             Path: /
             PayloadFormatVersion: "2.0"


### PR DESCRIPTION
Without `!Ref `, Lambda function fails to execute, because the resulting Lambda will be referencing an incorrect ARN (the literal "MyApi" string rather than what CloudFormation actually generated)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
