### PR TITLE
Update building-layers.md

### DIFF
--- a/doc_source/building-layers.md
+++ b/doc_source/building-layers.md
@@ -28,9 +28,9 @@ When you include the `Metadata` resource attribute section, you can use the `sam
 
 ## Examples<a name="building-applications-examples"></a>
 
-### Template example 1: Build a layer against the Python 3\.6 runtime environment<a name="building-applications-examples-python"></a>
+### Template example 1: Build a layer against the Python 3\.9 runtime environment<a name="building-applications-examples-python"></a>
 
-The following example AWS SAM template builds a layer against the Python 3\.6 runtime environment\.
+The following example AWS SAM template builds a layer against the Python 3\.9 runtime environment\.
 
 ```
 Resources:


### PR DESCRIPTION
Python version in section header and content didn't match.

*Issue #, if available:*

*Description of changes:*

The section header referenced Python 3.6, a runtime that's no longer available and doesn't match the content of the documentation.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
