### PR TITLE
Update monitor-app-insights.md

### DIFF
--- a/doc_source/monitor-app-insights.md
+++ b/doc_source/monitor-app-insights.md
@@ -51,13 +51,8 @@ Resources:
   ApplicationInsightsMonitoring:
     Type: AWS::ApplicationInsights::Application
       Properties:
-        ResourceGroupName:
-          Fn::Join:
-          - ''
-          - - ApplicationInsights-SAM-
-          - Ref: AWS::StackName
+        ResourceGroupName: !Ref ApplicationResourceGroup
         AutoConfigurationEnabled: 'true'
-    DependsOn: ApplicationResourceGroup
 ```
 +  `AWS::ResourceGroups::Group` – Creates a group to organize your AWS resources in order to manage and automate tasks on a large number of resources at one time\. Here, you create a resource group to use with CloudWatch Application Insights\. For more information on this resource type, see [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-resourcegroups-group.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-resourcegroups-group.html) in the *AWS CloudFormation User Guide*\. 
 +  `AWS::ApplicationInsights::Application` – Configures CloudWatch Application Insights for the resource group\. For more information on this resource type, see [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationinsights-application.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-applicationinsights-application.html) in the *AWS CloudFormation User Guide*\. 


### PR DESCRIPTION
The Application Insights application should use an intrinsic reference to the resource group rather than duplicating the string concatenation used to build the resource group name.  This has two benefits:  First, it creates an implicit dependency, removing the need for a `DependsOn`.  Second, if the name of the resource group changes, then the Application Insights will automatically be updated to reference the correct resource group.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
