### PR TITLE
Fixing typo: 3.9 runtime vs 3.6

### DIFF
--- a/doc_source/building-layers.md
+++ b/doc_source/building-layers.md
@@ -28,9 +28,9 @@ When you include the `Metadata` resource attribute section, you can use the `sam
 
 ## Examples<a name="building-applications-examples"></a>
 
-### Template example 1: Build a layer against the Python 3\.6 runtime environment<a name="building-applications-examples-python"></a>
+### Template example 1: Build a layer against the Python 3\.9 runtime environment<a name="building-applications-examples-python"></a>
 
-The following example AWS SAM template builds a layer against the Python 3\.6 runtime environment\.
+The following example AWS SAM template builds a layer against the Python 3\.9 runtime environment\.
 
 ```
 Resources:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updating typo in runtime to match the python version in the code sample below.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
